### PR TITLE
Fix a bug in func direction(self, direction)

### DIFF
--- a/openadk/models/motions_parameter.py
+++ b/openadk/models/motions_parameter.py
@@ -106,7 +106,7 @@ class MotionsParameter(object):
         :param direction: The direction of this MotionsParameter.  # noqa: E501
         :type: str
         """
-        allowed_values = ["left", "right", "both", "front", "back"]  # noqa: E501
+        allowed_values = ["left", "right", "both", "front", "back", "forward" ,"backward"]  # noqa: E501
         if direction not in allowed_values:
             raise ValueError(
                 "Invalid value for `direction` ({0}), must be one of {1}"  # noqa: E501


### PR DESCRIPTION
In line 104, the comment out code says that  

`When the \"name\" is \"walk\", \"direction\" value as below: - forward - backward - left - right`

However, the list of allowed_values doesn't contain 'forward' and 'backward', and it will raise valueError if we pass these two strings to the function direction(self, direction) in line 101.

And I just fix this bug.
